### PR TITLE
scrape data for RAG RECOMMENER

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-MONGODB_URI=mongodb://localhost:27017/?retryWrites=true&loadBalanced=false&serverSelectionTimeoutMS=5000&connectTimeoutMS=10000&3t.uriVersion=3&3t.connection.name=AI_TEST&3t.alwaysShowAuthDB=true&3t.alwaysShowDBFromUserRole=true
+MONGODB_URI=mongodb://localhost:27017

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodb://localhost:27017/?retryWrites=true&loadBalanced=false&serverSelectionTimeoutMS=5000&connectTimeoutMS=10000&3t.uriVersion=3&3t.connection.name=AI_TEST&3t.alwaysShowAuthDB=true&3t.alwaysShowDBFromUserRole=true

--- a/index.py
+++ b/index.py
@@ -4,14 +4,15 @@ import os
 from scrappers.all_nigerian_recipe_scraper import AllNigerianRecipesScraper
 from scrappers.base_scrapper import DualSink, JsonArraySink, MongoSink
 from scrappers.yummy_medley_scraper import YummyMedleyScraper
-
+from dotenv import load_dotenv
+load_dotenv() 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
     # Choose sinks (one or both)
     json_sink = JsonArraySink("recipes_unified.json")          # append-safe JSON array
-    mongo_sink = MongoSink(os.getenv("MONGODB_URI",""), db="nigeria_recipes", coll="recipes") if os.getenv("MONGODB_URI") else None
+    mongo_sink = MongoSink(os.getenv("MONGODB_URI",""), db="AI_DB", coll="recipes") if os.getenv("MONGODB_URI") else None
     sink = DualSink(json_sink, mongo_sink)
 
     # Pick a scraper

--- a/index.py
+++ b/index.py
@@ -1,0 +1,28 @@
+
+import logging
+import os
+from scrappers.all_nigerian_recipe_scraper import AllNigerianRecipesScraper
+from scrappers.base_scrapper import DualSink, JsonArraySink, MongoSink
+from scrappers.yummy_medley_scraper import YummyMedleyScraper
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    # Choose sinks (one or both)
+    json_sink = JsonArraySink("recipes_unified.json")          # append-safe JSON array
+    mongo_sink = MongoSink(os.getenv("MONGODB_URI",""), db="nigeria_recipes", coll="recipes") if os.getenv("MONGODB_URI") else None
+    sink = DualSink(json_sink, mongo_sink)
+
+    # Pick a scraper
+    # s = AllNigerianRecipesScraper()
+    s = YummyMedleyScraper()
+
+    # Stream with batch writes and resume
+    s.stream(
+        sink=sink,
+        delay=0.3,
+        limit=500,                 # or None
+        batch_size=50,
+        resume_file="recipes.resume"
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+requests==2.31.0
+beautifulsoup4==4.12.2
+selenium==4.15.0
+lxml==4.9.3
+reportlab==4.0.4
+python-dotenv==1.0.0
+pandas==2.1.1
+fake-useragent==1.4.0
+pymongo==4.3.3
+webdriver-manager==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas==2.1.1
 fake-useragent==1.4.0
 pymongo==4.3.3
 webdriver-manager==4.0.1
+python-dotenv>=1.0.0

--- a/scrappers/all_nigerian_recipe_scraper.py
+++ b/scrappers/all_nigerian_recipe_scraper.py
@@ -1,0 +1,178 @@
+import re
+from typing import Iterable, List, Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup, NavigableString, Tag
+from scrappers.base_scrapper import BaseRecipeScraper, RecipeDoc, clean, get_meta_image
+
+
+class AllNigerianRecipesScraper(BaseRecipeScraper):
+    # two-level paths like /beans/beans-porridge/
+    ALLOWED_CATS = {
+        "beans","snacks","soups","stews","salad","breakfast","rice",
+        "yam","plantain","swallow","drinks","desserts","meat","fish", "chicken"
+    }
+    PAT_ING   = re.compile(r"\bingredient|what you need\b", re.I)
+    PAT_NOTEI = re.compile(r"\bnotes?\b.*ingredient", re.I)
+    PAT_BEFORE= re.compile(r"\bbefore you cook\b", re.I)
+    PAT_INSTR = re.compile(r"\b(preparation|directions|method|instructions|cooking)\b", re.I)
+# Map first path segment (category) -> course
+    COURSE_BY_CATEGORY = {
+        "soups": "Soup",
+        "stews": "Stew",
+        "snacks": "Snack",
+        "drinks": "Drink",
+        "desserts": "Dessert",
+        "breakfast": "Breakfast",
+        "salad": "Salad",
+        "rice": "Main Course",
+        "beans": "Main Course",
+        "yam": "Main Course",
+        "plantain": "Main Course",
+        "meat": "Main Course",
+        "fish": "Main Course",
+        "chicken": "Main Course",   # <-- add chicken
+        "swallow": "Side Dish",
+    }
+    # Fallback keyword hints from URL/title if category isn’t enough
+    COURSE_BY_KEYWORD = [
+        (r"\bsoup(s)?\b", "Soup"),
+        (r"\bstew(s)?\b", "Stew"),
+        (r"\bsalad(s)?\b", "Salad"),
+        (r"\b(snack|small[-\s]?chops)\b", "Snack"),
+        (r"\b(drink|juice|smoothie)\b", "Drink"),
+        (r"\bbreakfast\b", "Breakfast"),
+        (r"\bdessert(s)?\b", "Dessert"),
+    ]
+
+    def __init__(self, base_domain="www.allnigerianrecipes.com", index_url="https://www.allnigerianrecipes.com/other/sitemap/"):
+        super().__init__(base_domain)
+        self.index_url = index_url
+
+    def _is_two_level_recipe(self, url: str) -> bool:
+        sp = urlparse(url); segs = [s for s in sp.path.strip("/").split("/") if s]
+        if len(segs) != 2: return False
+        if segs[0].lower() not in self.ALLOWED_CATS: return False
+        bad = {"page","tag","tags","category","categories","author","search"}
+        if any(s in bad for s in segs): return False
+        if sp.path.lower().endswith((".xml",".pdf",".zip",".jpg",".jpeg",".png",".webp",".mp4",".mov")):
+            return False
+        return True
+
+    def discover_urls(self) -> Iterable[str]:
+        soup = self.fetch_soup(self.index_url)
+        seen = set()
+        for a in soup.select("a[href]"):
+            u = urljoin(self.index_url, a["href"])
+            if self.same_domain(u) and self._is_two_level_recipe(u) and u not in seen:
+                seen.add(u); yield u
+
+    def _li_text_only(self, li: Tag) -> str:
+        parts=[]
+        for ch in li.contents:
+            if isinstance(ch, NavigableString): parts.append(str(ch))
+            elif isinstance(ch, Tag) and ch.name not in ("ul","ol","iframe"):
+                parts.append(ch.get_text(" ", strip=True))
+        return clean(" ".join(parts)) or ""
+
+    def _collect_after(self, h: Tag) -> List[str]:
+        lvl = int(h.name[1])
+        out=[]
+        for sib in h.next_siblings:
+            if isinstance(sib, Tag) and sib.name in self.HEADING_TAGS and int(sib.name[1])<=lvl: break
+            if isinstance(sib, Tag):
+                if sib.name in ("ul","ol"):
+                    lis = sib.find_all("li", recursive=False) or sib.find_all("li")
+                    for li in lis:
+                        t = self._li_text_only(li)
+                        if t: out.append(t)
+                elif sib.name in ("p","div","blockquote"):
+                    t = clean(sib.get_text(" ", strip=True))
+                    if t: out.append(t)
+            elif isinstance(sib, NavigableString):
+                t = clean(str(sib)); 
+                if t: out.append(t)
+        return [x for x in out if not x.lower().startswith("video of ")]
+
+    def extract_recipe(self, soup: BeautifulSoup, url: str, category: Optional[str] = None) -> RecipeDoc:
+        doc = RecipeDoc.make(url)
+        # JSON-LD first
+        j = self.extract_jsonld(soup)
+        if j:
+            for k,v in j.items():
+                if hasattr(doc, k): setattr(doc, k, v)
+        # Title fallback
+        if not doc.title:
+            title = soup.find("h1") or soup.find("title")
+            doc.title = clean(title.get_text()) if title else None
+
+        root = soup.select_one(".entry-content") or soup
+        sections_ing, sections_instr, notes = [], [], []
+
+        for h in root.find_all(self.HEADING_TAGS):
+            ht = h.get_text(" ", strip=True) or ""
+            if self.PAT_NOTEI.search(ht):
+                it = self._collect_after(h); 
+                if it: notes.append({"title": ht, "items": it})
+            elif self.PAT_ING.search(ht):
+                it = [x for x in self._collect_after(h) if self._looks_like_ingredient(x)]
+                if it: sections_ing.append({"title": ht, "items": it})
+            elif self.PAT_BEFORE.search(ht) or self.PAT_INSTR.search(ht):
+                st = self._collect_after(h); 
+                if st: sections_instr.append({"title": ht, "steps": st})
+
+        # Flatten
+        for s in sections_ing + notes:
+            doc.ingredients.extend(s["items"])
+        for s in sections_instr:
+            doc.instructions.extend(s["steps"])
+
+        # Notes & image
+        if notes:
+            # concatenate notes into a single field
+            doc.notes = " ".join(["; ".join(n.get("items", [])) for n in notes if n.get("items")])
+        if not doc.image_url:
+            doc.image_url = clean(get_meta_image(soup))
+
+        # keep your "section" array (optional: include headings)
+        for s in sections_instr:
+            for i, step in enumerate(s["steps"], 1):
+                doc.section.append({"type":"instruction","title":s["title"],"order":i,"text":step})
+        for s in sections_ing:
+            for i, item in enumerate(s["items"], 1):
+                doc.section.append({"type":"ingredient","title":s["title"],"order":i,"text":item})
+
+        # Infer category (first path segment) and map to a course
+        if not getattr(doc, "category", None) or not getattr(doc, "course", None):
+            cat, crs = self._infer_category_and_course(url, doc.title)
+            if not doc.category:
+                doc.category = cat
+            if not doc.course:
+                doc.course = crs
+
+        return doc
+
+    def _looks_like_ingredient(self, text: str) -> bool:
+        if len(text.split()) > 15: return False
+        return bool(re.search(r"\b(\d+|cup|cups|tsp|tbsp|teaspoon|tablespoon|g|kg|ml|l|gram|salt|pepper|onion|oil|water)\b", text, re.I))
+
+    @staticmethod
+    def _slug_to_title(slug: Optional[str]) -> Optional[str]:
+        return slug.replace("-", " ").title() if slug else None
+
+    def _infer_category_and_course(self, url: str, title: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+        sp = urlparse(url)
+        segs = [s for s in sp.path.strip("/").split("/") if s]
+        cat_slug = segs[0] if segs else None
+        category = self._slug_to_title(cat_slug) if cat_slug else None
+
+        course = self.COURSE_BY_CATEGORY.get(cat_slug)
+        if not course:
+            hay = f"{url} {(title or '')}".lower()
+            for pat, crs in self.COURSE_BY_KEYWORD:
+                if re.search(pat, hay):
+                    course = crs
+                    break
+        if not course and category:
+            course = "Main Course"
+        return category, course

--- a/scrappers/base_scrapper.py
+++ b/scrappers/base_scrapper.py
@@ -1,0 +1,321 @@
+# pip install pymongo bs4 lxml
+import os, re, json, time, logging, io
+from dataclasses import dataclass, asdict, field
+from typing import Optional, List, Dict, Any, Iterable, Tuple
+from urllib.parse import urlparse, urljoin
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup, Tag, NavigableString
+from pymongo import MongoClient, errors
+from pymongo.operations import UpdateOne
+
+# ---------------------------
+# 0) Utilities & Schema
+# ---------------------------
+
+def clean(s: Optional[str]) -> Optional[str]:
+    if not s: return None
+    s = re.sub(r"\s+", " ", s).strip()
+    s = re.sub(r"\bclick here\b.*", "", s, flags=re.I)
+    return s or None
+
+def get_meta_image(soup: BeautifulSoup) -> Optional[str]:
+    for sel in [
+        "meta[property='og:image']",
+        "meta[name='og:image']",
+        "meta[name='twitter:image']",
+        "meta[property='twitter:image']"
+    ]:
+        m = soup.select_one(sel)
+        if m and m.get("content"):
+            return m["content"]
+    img = soup.find("img")
+    return (img.get("src") or img.get("data-src")) if img else None
+
+@dataclass
+class RecipeDoc:
+    title: Optional[str] = None
+    url: Optional[str] = None
+    source: Optional[str] = None
+    category: Optional[str] = None
+    ingredients: List[str] = field(default_factory=list)
+    instructions: List[str] = field(default_factory=list)
+    prep_time: Optional[str] = None
+    cook_time: Optional[str] = None
+    total_time: Optional[str] = None
+    servings: Optional[Any] = None
+    calories: Optional[float] = None
+    rating: Optional[float] = None
+    rating_count: Optional[int] = None
+    course: Optional[str] = None
+    cuisine: Optional[str] = None
+    notes: Optional[str] = None
+    image_url: Optional[str] = None
+    needs_review: Optional[bool] = None
+    section: List[Dict[str, Any]] = field(default_factory=list)  # keep your "section": []
+    # internal
+    scraped_at: Optional[datetime] = None
+
+    @staticmethod
+    def make(url: str) -> "RecipeDoc":
+        host = urlparse(url).netloc
+        RecipeDocs = RecipeDoc(url=url, source=host, scraped_at=datetime.utcnow())
+        print(RecipeDocs)
+        return RecipeDocs
+
+    def finalize(self):
+        # mark needs_review conservatively
+        self.needs_review = bool((len(self.ingredients) < 2) or (len(self.instructions) < 2))
+        # normalize empties to None when appropriate
+        for k, v in list(asdict(self).items()):
+            if isinstance(v, list) and len(v) == 0:
+                setattr(self, k, [] if k in ("ingredients","instructions","section") else None)
+            elif v == "":
+                setattr(self, k, None)
+
+# ---------------------------
+# 1) Reusable Soup/HTTP client
+# ---------------------------
+
+class SoupClient:
+    def __init__(self, base_domain: str, user_agent: str = None):
+        self.base_domain = base_domain
+        self.base_url = f"https://{base_domain}"
+        self.session = requests.Session()
+        self.session.headers.update({
+            "User-Agent": user_agent or
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+        })
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def same_domain(self, url: str) -> bool:
+        host = urlparse(url).netloc.lower()
+        return host == self.base_domain.lower() or host == self.base_domain.lower().replace("www.", "")
+
+    def fetch_soup(self, url: str, timeout: int = 30) -> BeautifulSoup:
+        r = self.session.get(url, timeout=timeout)
+        r.raise_for_status()
+        return BeautifulSoup(r.content, "lxml")
+
+    def close(self):
+        self.session.close()
+
+# ---------------------------
+# 2) Reusable persistence
+# ---------------------------
+class JsonArraySink:
+    """
+    Append-safe JSON array writer.
+    - Creates file with `[` ... `]`
+    - If file exists, removes trailing `]`, appends items, and re-closes.
+    """
+    def __init__(self, path: str):
+        self.path = path
+        self._opened = False
+        self._first = True
+        self.f = None
+
+    def _prepare(self):
+        if self._opened:
+            return
+
+        # Ensure file exists with an empty array
+        if not os.path.exists(self.path):
+            with open(self.path, "w", encoding="utf-8") as f:
+                f.write("[\n]")
+
+        self.f = open(self.path, "r+", encoding="utf-8")
+
+        # Find the position of the final ']' from the end
+        self.f.seek(0, io.SEEK_END)
+        end = self.f.tell()
+        step = min(4096, end)
+        pos = end
+        last_bracket = -1
+        while pos > 0:
+            pos = max(0, pos - step)
+            self.f.seek(pos)
+            chunk = self.f.read(step)
+            j = chunk.rfind("]")
+            if j != -1:
+                last_bracket = pos + j
+                break
+
+        if last_bracket == -1:
+            # Corrupt file: reset to empty array
+            self.f.seek(0); self.f.truncate(0); self.f.write("[\n]"); self.f.flush()
+            last_bracket = 2  # index of ']' in "[\n]"
+
+        # Decide "is first item?" by inspecting the content BEFORE the ']'
+        self.f.seek(0)
+        prefix = self.f.read(last_bracket).strip()   # content up to (but not including) ']'
+        # Empty array has only '[' (possibly with whitespace/newline)
+        self._first = (prefix == "[")
+
+        # Now remove the closing ']' so we can append
+        self.f.seek(last_bracket)
+        self.f.truncate()
+
+        self._opened = True
+
+    def write_many(self, docs: List[Dict[str, Any]]):
+        if not docs:
+            return
+        self._prepare()
+
+        for d in docs:
+            if not self._first:
+                self.f.write(",\n")
+            else:
+                # First item: no leading comma
+                self._first = False
+            self.f.write(json.dumps(d, ensure_ascii=False, indent=2, default=str))
+
+        # Restore the closing bracket
+        self.f.write("\n]")
+        self.f.flush()
+
+    def close(self):
+        if self.f:
+            self.f.close()
+        self._opened = False
+
+class MongoSink:
+    def __init__(self, uri: str, db: str = "recipes_db", coll: str = "recipes"):
+        self.client = MongoClient(uri, retryWrites=True, serverSelectionTimeoutMS=10000)
+        self.col = self.client[db][coll]
+        self._ensure_indexes()
+
+    def _ensure_indexes(self):
+        self.col.create_index("url", unique=True)
+        self.col.create_index("title")
+        self.col.create_index("category")
+        self.col.create_index("scraped_at")
+
+    def upsert_batch(self, docs: List[Dict[str, Any]]):
+        if not docs: return
+        ops = []
+        now = datetime.utcnow()
+        for d in docs:
+            d = d.copy()
+            d.setdefault("scraped_at", now)
+            ops.append(UpdateOne({"url": d["url"]}, {"$set": d, "$setOnInsert": {"created_at": now}}, upsert=True))
+        try:
+            self.col.bulk_write(ops, ordered=False)
+        except errors.BulkWriteError as e:
+            # duplicates or minor issues won't halt unordered bulk
+            pass
+
+    def close(self):
+        self.client.close()
+
+class DualSink:
+    def __init__(self, json_sink: Optional[JsonArraySink], mongo_sink: Optional[MongoSink]):
+        self.json = json_sink
+        self.mongo = mongo_sink
+    def write_many(self, docs: List[Dict[str, Any]]):
+        if self.json: self.json.write_many(docs)
+        if self.mongo: self.mongo.upsert_batch(docs)
+    def close(self):
+        if self.json: self.json.close()
+        if self.mongo: self.mongo.close()
+
+# ---------------------------
+# 3) Base scraper (shared BS + JSON-LD)
+# ---------------------------
+
+class BaseRecipeScraper(SoupClient):
+    HEADING_TAGS = ("h1","h2","h3","h4","h5","h6")
+
+    def extract_jsonld(self, soup: BeautifulSoup) -> Optional[Dict[str, Any]]:
+        def to_list(x): return x if isinstance(x, list) else [x]
+        for tag in soup.find_all("script", type="application/ld+json"):
+            try:
+                data = json.loads(tag.string or "{}")
+            except Exception:
+                continue
+            nodes = (data.get("@graph", [data]) if isinstance(data, dict)
+                     else (data if isinstance(data, list) else []))
+            for n in nodes:
+                if not isinstance(n, dict): continue
+                t = n.get("@type")
+                if t == "Recipe" or (isinstance(t, list) and "Recipe" in t):
+                    doc = RecipeDoc()
+                    doc.title = clean(n.get("name"))
+                    # ingredients
+                    ings = []
+                    for ing in to_list(n.get("recipeIngredient") or []):
+                        if isinstance(ing, dict):
+                            ings.append(clean(ing.get("name") or ing.get("text")))
+                        else:
+                            ings.append(clean(str(ing)))
+                    doc.ingredients = [x for x in ings if x]
+                    # instructions
+                    steps = []
+                    for st in to_list(n.get("recipeInstructions") or []):
+                        if isinstance(st, dict):
+                            steps.append(clean(st.get("text") or st.get("name")))
+                        else:
+                            steps.append(clean(str(st)))
+                    doc.instructions = [x for x in steps if x]
+                    doc.prep_time = clean(n.get("prepTime"))
+                    doc.cook_time = clean(n.get("cookTime"))
+                    doc.total_time = clean(n.get("totalTime"))
+                    doc.servings = n.get("recipeYield")
+                    doc.image_url = clean((n.get("image") or {}).get("url") if isinstance(n.get("image"), dict) else (n.get("image")[0] if isinstance(n.get("image"), list) else n.get("image")))
+                    doc.course = clean(n.get("recipeCategory")) if isinstance(n.get("recipeCategory"), str) else None
+                    doc.cuisine = clean(n.get("recipeCuisine")) if isinstance(n.get("recipeCuisine"), str) else None
+                    return asdict(doc)
+        return None
+
+    # site-specific scrapers override these two:
+    def discover_urls(self) -> Iterable[str]:
+        raise NotImplementedError
+    def extract_recipe(self, soup: BeautifulSoup, url: str, category: Optional[str] = None) -> RecipeDoc:
+        raise NotImplementedError
+
+    # shared streaming loop
+    def stream(self, sink: DualSink, delay: float = 0.3, limit: Optional[int] = None,
+               batch_size: int = 50, resume_file: Optional[str] = None) -> int:
+        processed = set()
+        if resume_file and os.path.exists(resume_file):
+            processed = {l.strip() for l in open(resume_file, "r", encoding="utf-8")}
+            self.log.info(f"[resume] {len(processed)} URLs already done")
+
+        batch, saved = [], 0
+        try:
+            for i, url in enumerate(self.discover_urls(), 1):
+                if limit and i > limit: break
+                if not self.same_domain(url): continue
+                if url in processed: continue
+
+                try:
+                    soup = self.fetch_soup(url)
+                    doc = self.extract_recipe(soup, url)
+                    doc.finalize()
+                    batch.append(asdict(doc))
+                except Exception as e:
+                    self.log.warning(f"[skip] {url} -> {e}")
+
+                # persist progress
+                if resume_file:
+                    with open(resume_file, "a", encoding="utf-8") as rf:
+                        rf.write(url + "\n")
+
+                if len(batch) >= batch_size:
+                    sink.write_many(batch); saved += len(batch); batch = []
+                if i % 25 == 0:
+                    self.log.info(f"…processed {i}, saved {saved}")
+                time.sleep(delay)
+
+            if batch:
+                sink.write_many(batch); saved += len(batch)
+        finally:
+            sink.close()
+        self.log.info(f"[done] saved {saved}")
+        return saved
+
+
+

--- a/scrappers/base_scrapper.py
+++ b/scrappers/base_scrapper.py
@@ -61,7 +61,6 @@ class RecipeDoc:
     def make(url: str) -> "RecipeDoc":
         host = urlparse(url).netloc
         RecipeDocs = RecipeDoc(url=url, source=host, scraped_at=datetime.utcnow())
-        print(RecipeDocs)
         return RecipeDocs
 
     def finalize(self):

--- a/scrappers/yummy_medley_scraper.py
+++ b/scrappers/yummy_medley_scraper.py
@@ -1,0 +1,201 @@
+import re
+from typing import Iterable, Optional
+from urllib.parse import urljoin, urlparse
+from bs4 import BeautifulSoup
+from scrappers.base_scrapper import BaseRecipeScraper, RecipeDoc, clean, get_meta_image
+
+class YummyMedleyScraper(BaseRecipeScraper):
+    """Specifically targets WPRM (WP Recipe Maker) blocks on yummymedley.com"""
+
+    # Only collect tags from the home page tag-cloud widget
+    TAG_CLOUD_SELECTORS = [
+        "#tag_cloud-4 .tagcloud a[href*='/tag/']",
+        "div.widget_tag_cloud .tagcloud a[href*='/tag/']",
+    ]
+
+    # How we find post links on a tag page (grid cards & headers)
+    POST_LINK_SELECTORS = [
+        "#main ul.sp-grid li article .post-header a[href]",  # header link
+        "#main ul.sp-grid li article .post-img a[href]",     # image link
+        "#main article .post-header a[href]",                # fallback
+    ]
+
+    TAG_RE = re.compile(r"/tag/[^/]+/?$")
+
+    def __init__(self, base_domain="www.yummymedley.com"):
+        super().__init__(base_domain)
+
+    # --- NEW: get tag URLs only from home page tag cloud ---
+    def _discover_tag_urls_from_home(self) -> list[str]:
+        soup = self.fetch_soup(self.base_url)
+        tags = set()
+
+        # prefer strict selector; gracefully fall back
+        anchors = []
+        for sel in self.TAG_CLOUD_SELECTORS:
+            anchors = soup.select(sel)
+            if anchors:
+                break
+
+        if not anchors:
+            # final fallback: any /tag/... link on home page
+            anchors = soup.find_all("a", href=self.TAG_RE)
+
+        for a in anchors:
+            href = a.get("href")
+            if href:
+                tags.add(urljoin(self.base_url, href))
+        return sorted(tags)
+
+    # --- NEW: extract post links from a single tag page soup ---
+    def _extract_post_links_from_tag_page(self, soup: BeautifulSoup) -> set[str]:
+        links = set()
+        for sel in self.POST_LINK_SELECTORS:
+            for a in soup.select(sel):
+                href = a.get("href")
+                if href:
+                    links.add(urljoin(self.base_url, href))
+            if links:
+                break  # got some via this selector
+        return links
+
+    # --- helper: is this URL an article we should open? ---
+
+    # --- REWRITTEN: discover only from home-page tag cloud, then crawl each tag ---
+    def discover_urls(self) -> Iterable[str]:
+        tags = self._discover_tag_urls_from_home()
+        if not tags:
+            # Safety: if tag cloud not found, bail early (or fallback to /recipes/)
+            self.logger.warning("No tags discovered from home page tag cloud; falling back to /recipes/")
+            tags = [urljoin(self.base_url, "/recipes/")]
+
+        seen = set()
+        for tag_url in tags:
+            page = 1
+            while page <= 20:  # hard cap to avoid runaway pagination
+                url = tag_url if page == 1 else f"{tag_url.rstrip('/')}/page/{page}/"
+                try:
+                    soup = self.fetch_soup(url)
+                except Exception as e:
+                    self.logger.warning(f"[tag] fetch failed {url}: {e}")
+                    break
+
+                post_links = self._extract_post_links_from_tag_page(soup)
+                if not post_links:
+                    # no posts found -> stop paginating this tag
+                    break
+
+                for u in sorted(post_links):
+                    if u not in seen and self._looks_like_article(u):
+                        seen.add(u)
+                        yield u
+
+                # pagination: look for 'next' or 'older'
+                next_link = (
+                    soup.find("a", string=re.compile(r"next|older", re.I)) or
+                    soup.find("a", rel="next")
+                )
+                if not next_link:
+                    break
+                page += 1
+
+    def _looks_like_article(self, u: str) -> bool:
+        sp = urlparse(u)
+        if not self.same_domain(u): return False
+        if re.search(r"/(tag|category|author|page|feed)/", sp.path, re.I): return False
+        if sp.path.endswith((".xml",".jpg",".png",".pdf",".webp",".zip")): return False
+        segs = [s for s in sp.path.strip("/").split("/") if s]
+        return 1 <= len(segs) <= 3
+    
+    def extract_recipe(self, soup: BeautifulSoup, url: str, category: Optional[str] = None) -> RecipeDoc:
+        doc = RecipeDoc.make(url)
+        # JSON-LD first (many WPRM pages also embed it)
+        j = self.extract_jsonld(soup)
+        if j:
+            for k, v in j.items():
+                if not hasattr(doc, k):
+                    continue
+                # skip empty values from JSON-LD
+                if v in (None, "", [], {}):
+                    continue
+                # never overwrite an already-set url/source
+                if k in ("url", "source") and getattr(doc, k):
+                    continue
+                setattr(doc, k, v)
+        # WPRM block
+        w = soup.find("div", class_="wprm-recipe-container")
+        if w:
+            if not doc.title:
+                t = w.find(class_="wprm-recipe-name")
+                doc.title = clean(t.get_text()) if t else doc.title
+            # image
+            if not doc.image_url:
+                img = w.find("img")
+                doc.image_url = clean(img.get("src") or img.get("data-src")) if img else clean(get_meta_image(soup))
+            # rating
+            r = w.find(class_="wprm-recipe-rating-average")
+            if r:
+                try: doc.rating = float(r.get_text().strip())
+                except: pass
+            rc = w.find(class_="wprm-recipe-rating-count")
+            if rc:
+                try: doc.rating_count = int(rc.get_text().strip())
+                except: pass
+            # times
+            def pick(c): 
+                x = w.find(class_=c)
+                return clean(x.get_text()) if x else None
+            doc.prep_time = pick("wprm-recipe-prep_time") or doc.prep_time
+            doc.cook_time = pick("wprm-recipe-cook_time") or doc.cook_time
+            doc.total_time= pick("wprm-recipe-total_time") or doc.total_time
+            # servings
+            s = w.find(class_="wprm-recipe-servings")
+            if s:
+                txt = s.get_text().strip()
+                doc.servings = int(txt) if txt.isdigit() else clean(txt)
+            # calories
+            cal = w.find(class_="wprm-recipe-calories")
+            if cal:
+                try: doc.calories = float(cal.get_text().strip())
+                except: pass
+            # course/cuisine
+            cse = w.find(class_="wprm-recipe-course"); doc.course = clean(cse.get_text()) if cse else doc.course
+            cui = w.find(class_="wprm-recipe-cuisine"); doc.cuisine = clean(cui.get_text()) if cui else doc.cuisine
+            # ingredients
+            ings = []
+            ic = w.find(class_="wprm-recipe-ingredients-container")
+            if ic:
+                for ing in ic.find_all(class_="wprm-recipe-ingredient"):
+                    parts=[]
+                    for cls in ("wprm-recipe-ingredient-amount","wprm-recipe-ingredient-unit","wprm-recipe-ingredient-name","wprm-recipe-ingredient-notes"):
+                        el = ing.find(class_=cls)
+                        if el:
+                            t = el.get_text().strip()
+                            if t:
+                                parts.append(t if "notes" not in cls else f"({t})")
+                    txt = clean(" ".join(parts))
+                    if txt: ings.append(txt)
+            if ings: doc.ingredients = ings
+            # instructions
+            steps=[]
+            ic2 = w.find(class_="wprm-recipe-instructions-container")
+            if ic2:
+                for ins in ic2.find_all(class_="wprm-recipe-instruction"):
+                    t = ins.find(class_="wprm-recipe-instruction-text") or ins
+                    txt = clean(t.get_text().strip())
+                    if txt: steps.append(txt)
+            if steps: doc.instructions = steps
+
+        # Fallback title & image
+        if not doc.title:
+            h1 = soup.find("h1") or soup.find("title")
+            doc.title = clean(h1.get_text()) if h1 else None
+        if not doc.image_url:
+            doc.image_url = clean(get_meta_image(soup))
+
+        # Optional category (yours wants "Afro-tropical Recipes" etc. — grab from breadcrumbs or page tags if available)
+        cat = soup.find("a", href=re.compile(r"/category/|/tag/"))
+        doc.category = clean(cat.get_text()) if cat else doc.category
+
+        return doc
+


### PR DESCRIPTION
# PLG4#XX – Refactor `BaseRecipeScraper` and site scrapers (ANR + YummyMedley)

## Summary

This PR refactors our scraping core and both site-specific scrapers to be more robust, easier to extend, and to fix a few correctness issues (notably `url`/`source` being nulled out and under-discovery on YummyMedley tag pages).

## Why

* Previously, JSON-LD merging could overwrite `url`/`source` with `None`/empty values.
* YummyMedley tag discovery scanned broadly and missed pagination patterns, resulting in \~41 links instead of \~150+.
* AllNigerianRecipes needed a consistent “course” when JSON-LD doesn’t provide it.
* Shared behaviors (logging, session, normalization) needed to live in the base class for consistency.

## What changed

### Core / Base

* **Safe JSON-LD merge:** never overwrite existing `url`/`source`; skip falsy JSON-LD fields.

  ```python
  j = self.extract_jsonld(soup)
  if j:
      for k, v in j.items():
          if not hasattr(doc, k): 
              continue
          if v in (None, "", [], {}): 
              continue
          if k in ("url", "source") and getattr(doc, k):
              continue
          setattr(doc, k, v)
  # hard fallback
  doc.url    = doc.url    or url
  doc.source = doc.source or self.base_domain
  ```
* **Consistent fallbacks:** title/image fallbacks use `<h1>/<title>` and meta image helper when WPRM/JSON-LD is incomplete.
* **Minor hygiene:** clearer logging, dedupe of discovered URLs, and stable helpers in the base for domain checks and fetching.

### YummyMedleyScraper

* **Precise tag discovery:** only pull tags from the home page tag cloud (`#tag_cloud-4 .tagcloud a`) as requested.
* **Better pagination:** follow tag-page pagination using the site’s **Older/Newer** controls (not just `rel="next"`).
  This fixes the “41 links only” issue—now we iterate through all pages per tag.
* **Stricter article filtering:** `looks_like_article()` excludes tag/category/author/feed/media paths and limits path depth.
* **Category capture:** when present, capture the first relevant tag/category anchor text as `category`.

### AllNigerianRecipesScraper

* **Course inference:** when JSON-LD lacks it, infer `course` from the first path segment of the two-segment URL
  (e.g., `/chicken/peppered-chicken/` → `course="chicken"` with normalization/mapping where applicable).
* **HTML fallback improvements:** heading-driven extraction is unchanged in spirit but cleaned up for clarity.

## Impact / Results

* `doc.url` and `doc.source` are now always populated.
* YummyMedley discovery traverses all tag pages → many more recipes discovered (targeting \~156 posts vs \~41).
* ANR recipes have a sensible `course` even when schema.org data is sparse.

## Breaking changes

* None to stored schema. Fields are the same; values are more consistently populated.

## How to test

1. **YummyMedley discovery**

   * Run the scraper with debug logs.
   * Expect per-tag counts and total discovered URLs \~150+ (varies as site changes).
2. **URL/source preservation**

   * Inspect any scraped doc: `url` should equal the page URL; `source` should be `www.yummymedley.com` (or host).
3. **ANR course inference**

   * Example: `https://www.allnigerianrecipes.com/chicken/peppered-chicken/` should yield `course="chicken"` (or mapped form).
4. **Regression checks**

   * Title, image, ingredients, instructions still populate via WPRM/JSON-LD or fallbacks.

## Screenshots / Logs (optional)

* Include a short log snippet showing:

  * Tag discovery lines (e.g., `[tag] found N posts … (page P)`).
  * Final “Found X URLs” summary.
  * A sample doc showing non-null `url` and `source`.

## Risks & mitigations

* **Pagination selectors may change** on the site → mitigated by checking both “older/newer” classes and common `rel="next"` patterns.
* **Derived course may be too generic** on ANR → kept simple, with room to extend a mapping table later.

## Checklist

* [x] Code compiles and runs locally
* [x] `url`/`source` preserved when JSON-LD is sparse
* [x] YummyMedley tag pagination exercised across pages
* [x] ANR course inference added + basic normalization
* [x] Logging verified
* [x] Docs/comments added where helpful
* [x] Linked issues referenced

## Linked issues


