### PR TITLE
Add BaseEncoder abstraction and Hugging Face encoder provider

### DIFF
--- a/embedder/base_encoder.py
+++ b/embedder/base_encoder.py
@@ -1,0 +1,3 @@
+class BaseEncoder:
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        raise NotImplementedError

--- a/embedder/hugging_face_embedder.py
+++ b/embedder/hugging_face_embedder.py
@@ -1,0 +1,34 @@
+# embeddings.py
+from dataclasses import dataclass
+from typing import List, Sequence, Optional
+import numpy as np
+
+from embedder.base_encoder import BaseEncoder
+
+@dataclass
+class HFEmbedConfig:
+    model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
+    device: str = "cpu"  # or "cuda" for GPU
+    batch_size: int = 64
+    normalize: bool = True
+
+class HFEmbedder(BaseEncoder):
+    def __init__(self, cfg: Optional[HFEmbedConfig] = None):
+        self.cfg = cfg or HFEmbedConfig()
+        from sentence_transformers import SentenceTransformer
+        self._model = SentenceTransformer(self.cfg.model_name, device=self.cfg.device)
+
+
+    def encode(self, texts: Sequence[str]) -> List[List[float]]:
+        embs = self._model.encode(
+            list(texts),
+            batch_size=self.cfg.batch_size,
+            normalize_embeddings=self.cfg.normalize,
+            show_progress_bar=False,
+        )
+        # Ensure pure python lists (Mongo/JSON friendly)
+        if isinstance(embs, np.ndarray):
+            embs = embs.tolist()
+        else:
+            embs = [e.tolist() if hasattr(e, "tolist") else list(e) for e in embs]
+        return embs

--- a/index.py
+++ b/index.py
@@ -1,6 +1,7 @@
 
 import logging
 import os
+from embedder.hugging_face_embedder import HFEmbedder
 from scrappers.all_nigerian_recipe_scraper import AllNigerianRecipesScraper
 from scrappers.base_scrapper import DualSink, JsonArraySink, MongoSink
 from scrappers.yummy_medley_scraper import YummyMedleyScraper
@@ -17,8 +18,10 @@ if __name__ == "__main__":
 
     # Pick a scraper
     # s = AllNigerianRecipesScraper()
-    s = YummyMedleyScraper()
-
+    s = YummyMedleyScraper(
+    )
+    s.embedder = HFEmbedder() 
+    s.embedding_fields = [("ingredients", "ingredients_emb"), ("instructions", "instructions_emb")]
     # Stream with batch writes and resume
     s.stream(
         sink=sink,

--- a/scrappers/base_scrapper.py
+++ b/scrappers/base_scrapper.py
@@ -7,6 +7,8 @@ from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup, Tag, NavigableString
+from embedder.base_encoder import BaseEncoder
+from embedder.hugging_face_embedder import HFEmbedder
 from pymongo import MongoClient, errors
 from pymongo.operations import UpdateOne
 
@@ -78,7 +80,7 @@ class RecipeDoc:
 # ---------------------------
 
 class SoupClient:
-    def __init__(self, base_domain: str, user_agent: str = None):
+    def __init__(self, base_domain: str, user_agent: str = None, embedder= None):
         self.base_domain = base_domain
         self.base_url = f"https://{base_domain}"
         self.session = requests.Session()
@@ -228,6 +230,22 @@ class DualSink:
 class BaseRecipeScraper(SoupClient):
     HEADING_TAGS = ("h1","h2","h3","h4","h5","h6")
 
+    def __init__(
+        self,
+        *args,
+        embedder: "BaseEncoder | None" = None,
+        embedding_fields= None,
+        **kwargs
+    ):
+        """
+        embedder: HFEmbedder(), optional
+        embedding_fields: list of (source_field, target_field) like:
+            [("title", "title_emb"), ("instructions_text", "instr_emb")]
+        """
+        super().__init__(*args, **kwargs)
+        self.embedder = embedder
+        self.embedding_fields = embedding_fields or []
+
     def extract_jsonld(self, soup: BeautifulSoup) -> Optional[Dict[str, Any]]:
         def to_list(x): return x if isinstance(x, list) else [x]
         for tag in soup.find_all("script", type="application/ld+json"):
@@ -304,17 +322,59 @@ class BaseRecipeScraper(SoupClient):
                         rf.write(url + "\n")
 
                 if len(batch) >= batch_size:
+                    self._apply_embeddings(batch)
                     sink.write_many(batch); saved += len(batch); batch = []
                 if i % 25 == 0:
                     self.log.info(f"…processed {i}, saved {saved}")
                 time.sleep(delay)
 
             if batch:
+                self._apply_embeddings(batch)
                 sink.write_many(batch); saved += len(batch)
         finally:
             sink.close()
         self.log.info(f"[done] saved {saved}")
         return saved
 
+    def _apply_embeddings(self, batch: List[Dict[str, Any]]) -> None:
+        """
+        Applies embeddings to specified fields in a batch of documents.
+
+        For each (source_field, destination_field) pair in `self.embedding_fields`, this method:
+        - Extracts the value from `source_field` in each document of the batch.
+        - Converts the value to a string. If the value is a list, joins its elements with newlines.
+        - Handles `None` values by converting them to empty strings.
+        - Uses `self.embedder.encode` to generate embeddings for the processed texts.
+        - Stores the resulting embedding vector in `destination_field` of each document.
+
+        If `self.embedder`, `self.embedding_fields`, or `batch` is not set or empty, the method returns immediately.
+
+        Args:
+            batch (List[Dict[str, Any]]): A list of documents to process, where each document is a dictionary.
+
+        Returns:
+            None
+        """
+        if not self.embedder or not self.embedding_fields or not batch:
+            return
+
+        for src_field, dst_field in self.embedding_fields:
+            # Gather texts; coerce to strings.
+            texts: List[str] = []
+            for doc in batch:
+                val = doc.get(src_field)
+                if isinstance(val, list):
+                    # sensible default for ingredients/instructions: join with newline
+                    joined = "\n".join(str(x) for x in val)
+                    texts.append(joined)
+                elif val is None:
+                    texts.append("")
+                else:
+                    texts.append(str(val))
+
+            embs = self.embedder.encode(texts)
+            # Write back
+            for document, vec in zip(batch, embs):
+                document[dst_field] = vec
 
 

--- a/scrappers/yummy_medley_scraper.py
+++ b/scrappers/yummy_medley_scraper.py
@@ -2,6 +2,7 @@ import re
 from typing import Iterable, Optional
 from urllib.parse import urljoin, urlparse
 from bs4 import BeautifulSoup
+from embedder.hugging_face_embedder import HFEmbedder
 from scrappers.base_scrapper import BaseRecipeScraper, RecipeDoc, clean, get_meta_image
 
 class YummyMedleyScraper(BaseRecipeScraper):


### PR DESCRIPTION
### **Summary**

This PR introduces an encoder abstraction (`BaseEncoder`) to the scraping pipeline, allowing recipe text fields to be transformed into vector embeddings before persistence. The first provider implementation, `HFEmbedder`, uses Hugging Face’s `sentence-transformers` library. The design supports easy extension to other providers, such as OpenAI, Cohere, or custom models, without modifying the core scraping logic.

---

### **Motivation**

Previously, our scraping workflow saved text fields without any vector representation. By adding an encoder layer:

* We can enrich scraped data with embeddings for semantic search, clustering, or recommendation.
* Provider choice becomes decoupled from the scraping code, enabling runtime switching.
* Extensibility is improved — new encoder backends can be plugged in without changing `BaseRecipeScraper` or `DualSync`.

---

### **Changes Introduced**

1. **`BaseEncoder` abstract class**

   * Defines `encode(texts: list[str]) -> list[list[float]]`
   * Enforces a consistent interface for any embedding provider.

2. **`HFEmbedder` implementation**

   * Uses `sentence-transformers/all-MiniLM-L6-v2` by default.
   * Supports batch encoding of text fields.
   * Can run locally on CPU (Apple Silicon M1/M2 supported).

3. **`BaseRecipeScraper` updates**

   * Accepts optional `embedder` and `embedding_fields` in the constructor.
   * If provided, `_apply_embeddings()` is called before writing to sink.
   * `embedding_fields` is a list of `(source_field, target_field)` tuples.

4. **Example usage**

   ```python
   s = YummyMedleyScraper(
       embedder=HFEmbedder(),
       embedding_fields=[("ingredients", "ingredients_emb"), ("instructions", "instructions_emb")]
   )
   ```

5. **Extensibility for future encoders**

   * Adding OpenAI support requires only:

     * Implementing `OpenAIEmbedder(BaseEncoder)`.
     * Passing it into `embedder=` when creating the scraper.

---

### **Testing**

* Verified Hugging Face embedding runs locally on macOS Air M2.
* Confirmed that `embedding_fields` values are appended to the batch output before persistence.
* Tested fallback behavior when `embedder` is `None`.

---

### **Next Steps**

* Add OpenAI encoder provider.
* Add CLI option for selecting encoder provider at runtime.
* Benchmark embedding speed for large batch sizes.

---

### **Checklist**

* [x] Follows PR template guidelines.
* [x] Adds no breaking changes for existing scrapers without embeddings.
* [x] Includes docstrings and type hints.
* [x] Tested on macOS Air M2 with CPU backend.


